### PR TITLE
新規登録画面のエラーメッセージの日本語化

### DIFF
--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -33,8 +33,18 @@ ja:
         birth_year: 生まれた年
         birth_month: 誕生月
         birth_day: 誕生日
+      address:
+        send_last_name: 送り先氏名の名字
+        send_first_name: 送り先氏名の名前
+        send_last_name_kana: 送り先氏名の名字（カナ）
+        send_first_name_kana: 送り先氏名の名前（カナ）
+        postal_code: 郵便番号
+        city: 市町村
+        house_number: 番地
+        room_number: 部屋番号
     models:
-      user: ユーザ
+      user: ユーザー
+      address: 送り先情報
   devise:
     confirmations:
       confirmed: メールアドレスが確認できました。


### PR DESCRIPTION
# What
新規登録画面のエラーメッセージの日本語化をした。

# Why
ユーザーにとってエラーの原因をわかりやすくするため。