### PR TITLE
cardモデルにバリデーションを指定

### DIFF
--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -1,4 +1,6 @@
 class Card < ApplicationRecord
   belongs_to :user
-  has_many :purchases
+
+  validates :card_number, presence: true
+  validates :customer_id, presence: true
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -16,5 +16,4 @@ class Item < ApplicationRecord
   validates :days, presence: true
   validates :images, presence: true
 
-  has_one :purchase, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,8 +9,6 @@ class User < ApplicationRecord
   has_many :selling_items, -> { where("buyer_id is NULL") }, foreign_key: "seller_id", class_name: "Item", dependent: :destroy
   has_many :sold_items, -> { where("buyer_id is not NULL") }, foreign_key: "seller_id", class_name: "Item", dependent: :destroy
   has_many :cards, dependent: :destroy
-  has_many :purchases_of_seller, class_name: 'Purchase', foreign_key: 'seller_id'
-  has_many :purchases_of_buyer, class_name: 'Purchase', foreign_key: 'buyer_id'
 
   validates :nickname, :email, presence: true
   validates :last_name, :first_name, presence: true, format: {with: /\A[ぁ-んァ-ン一-龥]/}


### PR DESCRIPTION
# what
カードモデルにバリデーションをかけた。
purchaseモデルは削除したのでアソシエーションを削除した。

# Why
payjpで生成される暗号化されたデータを空で管理しないため。
purchaseにかかるアソシエーションがなくなったため。